### PR TITLE
Give a hint that DebOps Standards are not yet defined

### DIFF
--- a/_includes/status.md
+++ b/_includes/status.md
@@ -9,7 +9,7 @@ There are <span id="role_count">?</span> roles in the DebOps project.
       <th>CI status</th>
       <th id="ci_test">CI tests</th>
       <th>Release</th>
-      <th>DebOps Standards</th>
+      <th><span title="Not yet documented. Check the most recent version you can find if you are looking for a good example role.">DebOps Standards</span></th>
       <th id="maintainer">Role Maintainers</th>
     </tr>
   </thead>


### PR DESCRIPTION
Technically, there is no really Standard yet to define as we are still
in 0.x but of course a documentation would be in place. It just does not
exist yet. This shows a hint on mouse hover.

cc: @AnBuKu