### PR TITLE
Add docs reference as separate column to the status page

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -46,6 +46,22 @@
     return a;
   }
 
+  function docs(metadata, role_full_name) {
+    if (metadata.hasOwnProperty('docs_url')) {
+      var elem = document.createElement('a');
+      elem.setAttribute('href', metadata.docs_url);
+      elem.innerHTML = '→';
+    } else {
+      var elem = document.createElement('span');
+      elem.innerHTML = 'n.&#x202F;a.';
+      elem.setAttribute('title', 'There is no rendered version of the documentation available. Either because the role has not been documneted yet or because it is not fully up-to-date. You can help us improve that it!');
+    }
+
+    elem.setAttribute('class', 'item_attr');
+
+    return elem;
+  }
+
   function role_format_version(metadata, role_full_name) {
     var span = document.createElement('span');
     span.setAttribute('class', 'item_attr');
@@ -123,9 +139,10 @@
           row.insertCell(0).appendChild(github_repo(data[key], key));
           row.insertCell(1).appendChild(travis_badge(data[key], key));
           row.insertCell(2).appendChild(testsuite_link(data[key], key));
-          row.insertCell(3).appendChild(role_version(data[key], key));
-          row.insertCell(4).appendChild(role_format_version(data[key], key));
-          row.insertCell(5).appendChild(get_maintainers(data[key], key));
+          row.insertCell(3).appendChild(docs(data[key], key));
+          row.insertCell(4).appendChild(role_version(data[key], key));
+          row.insertCell(5).appendChild(role_format_version(data[key], key));
+          row.insertCell(6).appendChild(get_maintainers(data[key], key));
         }
       }
       document.getElementById('role_count').innerHTML = role_count;

--- a/_includes/status.md
+++ b/_includes/status.md
@@ -8,6 +8,7 @@ There are <span id="role_count">?</span> roles in the DebOps project.
       <th id="role_name">Role name</th>
       <th>CI status</th>
       <th id="ci_test">CI tests</th>
+      <th>Docs</th>
       <th>Release</th>
       <th>DebOps Standards</th>
       <th id="maintainer">Role Maintainers</th>

--- a/css/status_page.css
+++ b/css/status_page.css
@@ -1,5 +1,5 @@
 .container {
-  max-width: 45rem;
+  max-width: 55rem;
   margin: 0 auto;
   padding: 0 1rem;
 }


### PR DESCRIPTION
Hugi had the idea that a direct docs link could be useful.

As the information is already [provided by the DebOps API](https://docs.debops.org/en/latest/debops-api/docs/api-reference-v0.html#role-metadata-json-format) I thought lets just try it and I must say, I think it makes sense to make the table a bit wider again to add a quick link to the end user docs.

Here is how it looks like: 
![screenshot from 2016-11-05 01 38 11](https://cloud.githubusercontent.com/assets/1301158/20026387/4948b132-a2fa-11e6-86cb-18670d153907.png)

CC: @AnBuKu
Idea by: @AnBuKu
Thanks to:  @AnBuKu
Closes: #48